### PR TITLE
ICatFR compatability

### DIFF
--- a/event_creation/submission/events_tasks.py
+++ b/event_creation/submission/events_tasks.py
@@ -234,6 +234,7 @@ class EventCreationTask(PipelineTask):
                 'FR': FRHostPCLogParser,
                 #'catFR': catFRHostPCLogParser,
                 'catFR': CatFRSessionLogParser,
+                'ICatFR': CatFRSessionLogParser,
                 'PS': PSLogParser,
                 'PS_FR': PSLogParser,
                 'PS_catFR': PSLogParser,
@@ -252,6 +253,7 @@ class EventCreationTask(PipelineTask):
                 'OPS': BaseElememLogParser,
                 'FR': ElememFRLogParser,
                 'catFR': ElememCatFRLogParser,
+                'ICatFR': ElememCatFRLogParser,
                 'EFRCourierReadOnly': ElememEFRCourierParser,
                 'EFRCourierOpenLoop': ElememEFRCourierParser,
             }

--- a/event_creation/submission/pipelines.py
+++ b/event_creation/submission/pipelines.py
@@ -57,6 +57,8 @@ def determine_groups(protocol, subject, full_experiment, session, transfer_cfg_f
     if '_' in full_experiment:
         groups += (full_experiment.split('_')[0],)
         experiment = full_experiment.partition('_')[-1]
+    elif full_experiment.startswith('I'):               # re-route ICatFR to same pipeline process as CatFR
+        experiment = full_experiment[1:]
     else:
         experiment = full_experiment
     if protocol == 'r1' and 'FR5' in experiment:

--- a/event_creation/submission/pipelines.py
+++ b/event_creation/submission/pipelines.py
@@ -53,15 +53,16 @@ N_PS4_SESSIONS = 10
 
 def determine_groups(protocol, subject, full_experiment, session, transfer_cfg_file, *args, **kwargs):
     groups = (protocol,)
-    
+    recog = True                                        # toggle to bypass 'recog' group
     if '_' in full_experiment:
         groups += (full_experiment.split('_')[0],)
         experiment = full_experiment.partition('_')[-1]
     elif full_experiment.startswith('I'):               # re-route ICatFR to same pipeline process as CatFR
         experiment = full_experiment[1:]
+        recog = False
     else:
         experiment = full_experiment
-    if protocol == 'r1' and 'FR5' in experiment:
+    if protocol == 'r1' and 'FR5' in experiment and recog:
         groups += ('recog',)
     exp_type = re.sub(r'[^A-Za-z]', '', experiment)
 


### PR DESCRIPTION
Re-route ICatFR entries to same pipelines as CatFR entries.  Should work since only difference is no math distractor events.