### PR TITLE
Math sys4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2023-7-26
+===================
+- System 3 and system 4 event creation supported by same codebase
+- Added parser for system 4 math events
+- Added support for ICatFR and IFR experiments (read only)
+
 2021-6-2 (v2.0.0)
 ===================
 - Moved to Python 3 (following the deprecation of Python 2). Not all legacy experiments are fully supported in Python 3 at this point. All modern UnityEPL experiments are supported. 

--- a/event_creation/submission/alignment/system4.py
+++ b/event_creation/submission/alignment/system4.py
@@ -17,8 +17,8 @@ class System4Offset:
         self.eeg = mne.io.read_raw_edf(self.eeg_file, preload=True)
         self.ev_ms = events.view(np.recarray).mstime
         self.events = events.view(np.recarray)
-        logger.debug("Event fields = {}".format(events.view(np.recarray).dtype.names))
-        logger.debug("eeg_dir = {}, eeg_file = {}".format(eeg_dir, self.eeg_file))
+        #logger.debug("Event fields = {}".format(events.view(np.recarray).dtype.names))
+        #logger.debug("eeg_dir = {}, eeg_file = {}".format(eeg_dir, self.eeg_file))
     
     @staticmethod
     def extract_eegstart(logfile):

--- a/event_creation/submission/configuration/config.yml
+++ b/event_creation/submission/configuration/config.yml
@@ -1,6 +1,6 @@
 
 paths : &PATHS
-  rhino_root     : &RHINO '/'
+  rhino_root     : &RHINO '/home1/hherrema/programming_data/local_rhino/'
   data_root      : !join [*RHINO,'data','eeg']
   loc_db_root    : !join [*RHINO, 'home2', 'RAM_maint', 'stim']
   db_root        : *RHINO

--- a/event_creation/submission/configuration/config.yml
+++ b/event_creation/submission/configuration/config.yml
@@ -1,6 +1,6 @@
 
 paths : &PATHS
-  rhino_root     : &RHINO '/home1/hherrema/programming_data/local_rhino/'
+  rhino_root     : &RHINO '/'
   data_root      : !join [*RHINO,'data','eeg']
   loc_db_root    : !join [*RHINO, 'home2', 'RAM_maint', 'stim']
   db_root        : *RHINO

--- a/event_creation/submission/events_tasks.py
+++ b/event_creation/submission/events_tasks.py
@@ -331,7 +331,7 @@ class EventCreationTask(PipelineTask):
         parser = self.parser_type(self.protocol, self.subject, self.montage, self.experiment, self.session, files)
         logger.debug('Using %s' % str(self.parser_type))
         unaligned_events = parser.parse()
-        logger.debug("unaligned events = {}".format(unaligned_events))
+        #logger.debug("unaligned events = {}".format(unaligned_events))
         # SCALP LAB SPECIFIC PROCESSING - Alignment, blink detection, and data cleaning
         if self.protocol == 'ltp':
             sync_log = files['eeg_log'] if 'eeg_log' in files else []

--- a/event_creation/submission/parsers/base_log_parser.py
+++ b/event_creation/submission/parsers/base_log_parser.py
@@ -339,7 +339,7 @@ class BaseLogParser(object):
             # Modify existing events if necessary
             if this_type in self._type_to_modify_events:
                 events = self._type_to_modify_events[this_type](events.view(np.recarray))
-        logger.debug("Events type = {}; Events = {}".format(type(events), events))
+        #logger.debug("Events type = {}; Events = {}".format(type(events), events))
         # Remove first (empty) event
         if events.ndim > 0:
             return events[1:]

--- a/event_creation/submission/parsers/math_parser.py
+++ b/event_creation/submission/parsers/math_parser.py
@@ -218,12 +218,14 @@ class MathElememLogParser(BaseElememLogParser):    # parse events.log for math/d
             MATH = self.events_math,
             DISTRACT = self.events_distract,
         )
+        """
         logger.debug("attributes: subject = {}, experiment = {}, protocol = {}, montage = {}, session = {}".format(
             self._subject, self._experiment, self._protocol, self._montage, self._session
         ))
         logger.debug("arguments: subject = {}, experiment = {}, protocol = {}, montage = {}, session = {}, files = {}".format(
             subject, experiment, protocol, montage, session, files
         ))
+        """
 
     # override method in BaseElememLogParser -> only reading MATH and DISTRACT events
     def _read_event_log(self, filename):
@@ -234,10 +236,10 @@ class MathElememLogParser(BaseElememLogParser):    # parse events.log for math/d
                   'test': [int(x) for x in re.findall(r'\d+', row.data[self.TEST_FIELD])], 
                   'iscorrect': int(bool(row.data[self.ISCORRECT_FIELD])), 
                   'rectime': int(row.data[self.RECTIME_FIELD]), 
-                  'mstime': int(row.time),         # don't subtract rectime
-                  #'mstime': int(row.time - int(row.data[self.RECTIME_FIELD])), 
-                  'type': 'MATH'} if row.type == 'MATH' else 
-                  {'answer': -999, 'test': [0,0,0], 'iscorrect': -999, 'rectime': -999, 'mstime': int(row.time), 'type': 'DISTRACT'} 
+                  #'mstime': int(row.time),         # don't subtract rectime
+                  'mstime': int(row.time - int(row.data[self.RECTIME_FIELD])), 
+                  'type': 'PROB'} if row.type == 'MATH' else 
+                  {'answer': -999, 'test': [0,0,0], 'iscorrect': -999, 'rectime': -999, 'mstime': int(row.time), 'type': 'DISTRACT_START'} 
                   if row.type == 'DISTRACT' else {} for _, row in md.iterrows()]
         df_md = pd.DataFrame.from_records(md_ra)       # convert back to dataframe to add fields
         df_md['subject'] = self._subject
@@ -255,7 +257,7 @@ class MathElememLogParser(BaseElememLogParser):    # parse events.log for math/d
         list_col = np.zeros(len(df_md.index), dtype=int)
         l = -1
         for idx in range(len(list_col)):
-            if idx in df_md.loc[df_md['type']=='DISTRACT'].index:
+            if idx in df_md.loc[df_md['type']=='DISTRACT_START'].index:
                 l += 1
             list_col[idx] = int(l)
         df_md['list'] = list_col

--- a/event_creation/submission/parsers/math_parser.py
+++ b/event_creation/submission/parsers/math_parser.py
@@ -236,7 +236,7 @@ class MathElememLogParser(BaseElememLogParser):    # parse events.log for math/d
                   'rectime': int(row.data[self.RECTIME_FIELD]), 
                   'mstime': int(row.time - int(row.data[self.RECTIME_FIELD])), 
                   'type': 'MATH'} if row.type == 'MATH' else 
-                  {'answer': -999, 'test': [0,0,0], 'iscorrect': -999, 'mstime': int(row.time), 'type': 'DISTRACT'} 
+                  {'answer': -999, 'test': [0,0,0], 'iscorrect': -999, 'rectime': -999, 'mstime': int(row.time), 'type': 'DISTRACT'} 
                   if row.type == 'DISTRACT' else {} for _, row in md.iterrows()]
         df_md = pd.DataFrame.from_records(md_ra)       # convert back to dataframe to add fields
         df_md['subject'] = self._subject

--- a/event_creation/submission/parsers/math_parser.py
+++ b/event_creation/submission/parsers/math_parser.py
@@ -253,9 +253,13 @@ class MathElememLogParser(BaseElememLogParser):    # parse events.log for math/d
         md_dl = [e.to_dict() for _, e in df_md.iterrows()]    # list of dictionaries
         dtype = np.dtype([(key, self.dtypes.get(key)) for key in md_dl[0].keys()])   # dtypes of each field (order invariant)
         record_array = np.empty(len(md_dl), dtype=dtype)      # convert to record array
-        for i, d in enumerate(md_dl):
-            for k, v in d.items():
-                record_array[k][i] = v
+        try:
+            for i, d in enumerate(md_dl):
+                for k, v in d.items():
+                    record_array[k][i] = v
+        except BaseException as be:
+            print(be)
+            print("i = {}, d = {}, k = {}, v = {}".format(i,d,k,v))
         
         return record_array
     


### PR DESCRIPTION
Lots of changes/testing but in the end system 4 now has a math parser, and PROB (math) and DISTRACT_START events are now part of the structure loaded in cmlreaders.  Some previous system 4 catFR subjects will need events re-created.  Also, testing will need to be done for stim sessions.  

Currently the math/distractor events are given default values for fields ['stim_list', 'is_stim', 'msoffset'].  So more to look into...