### PR TITLE
System 3 n_samples

### DIFF
--- a/event_creation/submission/readers/eeg_reader.py
+++ b/event_creation/submission/readers/eeg_reader.py
@@ -139,7 +139,9 @@ class HD5_reader(EEG_reader):
 
     @property
     def by_row(self):
-         return 'orient' in self.h5file.root.timeseries.attrs and  self.h5file.root.timeseries.attrs['orient']=='row'
+         return ('orient' in self.h5file.root.timeseries.attrs and
+                 (self.h5file.root.timeseries.attrs['orient']=='row' or
+                  self.h5file.root.timeseries.attrs['orient']==b'row'))
 
     def get_start_time(self):
         try:


### PR DESCRIPTION
Correct error for system 3 sessions writing wrong n_samples to sources.json. System 3.6 (current version) has h5 files with `orient = b'row'` instead of `orient` = 'row'.  Updated proper conditional statement to handle.